### PR TITLE
Rhel proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This Ansible role installs the ZFS filesystem module, creates or imports zpools 
 | `zfs_redhat_style` | `kmod` | Style of ZFS module installation. Can be either kmod or dkms.  Applies only to RedHat systems. See [official documentation](https://openzfs.github.io/openzfs-docs/Getting%20Started/RHEL-based%20distro/index.html#rhel-based-distro) for information on DKMS and kmod version of openZFS. |
 | `zfs_redhat_repo_dkms_url` | `http://download.zfsonlinux.org/`<br>`epel/{{ ansible_distribution_version }}/$basearch/` | Repository URL used for DKMS installation of ZFS. Applies only to RedHat systems. |
 | `zfs_redhat_repo_kmod_url` | `http://download.zfsonlinux.org/`<br>`epel/{{ ansible_distribution_version }}/kmod/$basearch/` | Repository URL used for kmod installation of ZFS. Applies only to RedHat systems. |
+| `zfs_redhat_repo_proxy` |  | YUM/DNF repository proxy URL |
 | `zfs_debian_repo` | `{{ ansible_distribution_release }}-backports` | Repository used for installation. Applies only to Debian systems. |
 | `zfs_service_import_cache_enabled` | `true` | Enable service to import ZFS pools by cache file. |
 | `zfs_service_import_scan_enabled` | `false` | Enable service to import ZFS pools by device scanning. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@
 zfs_redhat_style: kmod
 zfs_redhat_repo_dkms_url: "http://download.zfsonlinux.org/epel/{{ ansible_distribution_version }}/$basearch/"
 zfs_redhat_repo_kmod_url: "http://download.zfsonlinux.org/epel/{{ ansible_distribution_version }}/kmod/$basearch/"
+zfs_redhat_repo_proxy:
 
 # installation on Debian systems
 zfs_debian_repo: "{{ ansible_distribution_release }}-backports"

--- a/templates/etc/yum.repos.d/zfs.repo.j2
+++ b/templates/etc/yum.repos.d/zfs.repo.j2
@@ -7,6 +7,9 @@ enabled         = {{ (zfs_redhat_style == 'dkms') | ternary(1,0) }}
 metadata_expire = 7d
 gpgcheck        = 1
 gpgkey          = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
+{% if zfs_redhat_repo_proxy | default('') %}
+proxy           = {{ zfs_redhat_repo_proxy }}
+{% endif %}
 
 [zfs-kmod]
 name            = ZFS on Linux for EL{{ ansible_distribution_version }} - kmod
@@ -15,3 +18,6 @@ enabled         = {{ (zfs_redhat_style == 'kmod') | ternary(1,0) }}
 metadata_expire = 7d
 gpgcheck        = 1
 gpgkey          = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
+{% if zfs_redhat_repo_proxy | default('') %}
+proxy           = {{ zfs_redhat_repo_proxy }}
+{% endif %}

--- a/templates/etc/yum.repos.d/zrepl.repo.j2
+++ b/templates/etc/yum.repos.d/zrepl.repo.j2
@@ -6,3 +6,6 @@ baseurl         = {{ zfs_zrepl_redhat_repo_url }}
 metadata_expire = 7d
 gpgcheck        = 1
 gpgkey          = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-zfsonlinux
+{% if zfs_redhat_repo_proxy | default('') %}
+proxy           = {{ zfs_redhat_repo_proxy }}
+{% endif %}


### PR DESCRIPTION
Add support for http/https proxy on RHEL based systems. This allows a proxy to be configured for the ZFS repository.

It is worth noting that this proxy configuration is specific to RHEL based systems as proxy configuration is specific to each repository. In Debian based systems the proxy configuration is for the whole APT system and not per repository.