### PR TITLE
Add support for both jinja 2.x & 3.x to selectattr2

### DIFF
--- a/filter_plugins/selectattr2.py
+++ b/filter_plugins/selectattr2.py
@@ -23,8 +23,13 @@
 from collections.abc import Iterable
 
 from ansible import errors
-from jinja2.utils import pass_environment
 from jinja2.runtime import Undefined
+
+try:
+	from jinja2.filters import pass_environment
+except ImportError:
+	from jinja2.filters import environmentfilter
+	pass_environment = environmentfilter
 
 
 class FilterModule(object):


### PR DESCRIPTION
Tested on:

ansible 2.14.3 with jinja 3.1.2 (Debian 12.1 "bookworm" ansible package) ansible 2.10.8 with jinja 2.11.3 (Debian 11.7 "bullseye" ansible package)