### PR TITLE
clear zfs_facts to avoid stale data if filesystem does not exist

### DIFF
--- a/tasks/manage_filesystem.yml
+++ b/tasks/manage_filesystem.yml
@@ -8,6 +8,12 @@
     quiet: true
     fail_msg: ZFS filesystem parameters are invalid
 
+# Filesystem may not exist, so clear fact from any previous call, then
+# try to get facts for the thing.    
+- name: clear filesystem properties
+  ansible.builtin.set_fact:
+    ansible_zfs_datasets: []
+
 - name: gather properties of '{{ zfs_filesystem.name | mandatory }}'
   community.general.zfs_facts:
     name: "{{ zfs_filesystem.name }}"


### PR DESCRIPTION
If the filesystem does not exist, ansible_zfs_datasets may contain data from a previous invocation of zfs_facts.    Added a task to clear the fact before trying to set it in manage_filesystem.yml

I noticed this when creating a pool with case sensitive, then in a later run trying to create a filesystem in it with case mixed.  Your "prepare" script kept giving me an error that the case couldn't be changed after creation, but this was a new filesys.   Eventually realized that it was using the facts harvested from the pool because the zfs_facts for the new, non-existent filesys failed (but was ignored).